### PR TITLE
fix: addChangeHandler callback needs previous and current state

### DIFF
--- a/docs/globals.html
+++ b/docs/globals.html
@@ -192,14 +192,16 @@ swap(countAtom, (state) =&gt; ({ <span class="hljs-attr">count</span>: state.cou
 									<ul class="tsd-parameters">
 										<li class="tsd-parameter-siganture">
 											<ul class="tsd-signatures tsd-kind-type-literal tsd-is-not-exported">
-												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>state<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">S</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+												<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span>states<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 											</ul>
 											<ul class="tsd-descriptions">
 												<li class="tsd-description">
 													<h4 class="tsd-parameters-title">Parameters</h4>
 													<ul class="tsd-parameters">
 														<li>
-															<h5>state: <span class="tsd-signature-type">S</span></h5>
+															<h5>states: <span class="tsd-signature-type">object</span></h5>
+															<ul class="tsd-parameters">
+															</ul>
 														</li>
 													</ul>
 													<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -319,7 +321,7 @@ validator({ <span class="hljs-attr">count</span>: <span class="hljs-number">2</s
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in changeHandler.ts:31</li>
+									<li>Defined in changeHandler.ts:35</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -357,7 +359,7 @@ validator({ <span class="hljs-attr">count</span>: <span class="hljs-number">2</s
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in set.ts:27</li>
+									<li>Defined in set.ts:28</li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/changeHandler.ts
+++ b/src/changeHandler.ts
@@ -20,7 +20,11 @@ swap(countAtom, (state) => ({ count: state.count + 1 }))
 // stdout logs: { count: 1 }
 ```
  */
-export function addChangeHandler<S>(atom: Atom<S>, key: string, handler: (state: S) => void) {
+export function addChangeHandler<S>(
+  atom: Atom<S>,
+  key: string,
+  handler: (states: { previous: S; current: S }) => void
+) {
   _addChangeHandler(atom, key, handler);
 }
 

--- a/src/internal-state.ts
+++ b/src/internal-state.ts
@@ -36,7 +36,11 @@ export function _initChangeHandlerDict(atom: Atom<any>) {
 }
 
 /** @ignore */
-export function _addChangeHandler<S>(atom: Atom<S>, key: string, handler: (state: S) => void) {
+export function _addChangeHandler<S>(
+  atom: Atom<S>,
+  key: string,
+  handler: (states: { previous: S; current: S }) => void
+) {
   if (typeof changeHandlersByAtomId[atom["$$id"]][key] === "function") {
     throw new Error(
       `Change handler already registered for key "${key}" on ${atom}.\nRemove the existing handler before registering a new one.`
@@ -51,8 +55,8 @@ export function _removeChangeHandler<S>(atom: Atom<S>, key: string) {
 }
 
 /** @ignore */
-export function _runChangeHandlers<S>(atom: Atom<S>) {
+export function _runChangeHandlers<S>(atom: Atom<S>, previous: S, current: S) {
   Object.keys(changeHandlersByAtomId[atom["$$id"]]).forEach(k => {
-    changeHandlersByAtomId[atom["$$id"]][k](_getState(atom));
+    changeHandlersByAtomId[atom["$$id"]][k]({ previous, current });
   });
 }

--- a/src/set.ts
+++ b/src/set.ts
@@ -1,4 +1,5 @@
 import { Atom } from "./atom";
+import { deref } from "./deref";
 import { _getValidator, _runChangeHandlers, _setState } from "./internal-state";
 import { DeepImmutable } from "./internal-types";
 import { _prettyPrint, _throwIfNotAtom } from "./utils";
@@ -37,7 +38,8 @@ export function set<S>(atom: Atom<S>, nextState: S): void {
 
     throw err;
   } else {
+    const prevState = deref(atom);
     _setState(atom, nextState);
-    _runChangeHandlers(atom);
+    _runChangeHandlers(atom, prevState as S, nextState);
   }
 }

--- a/src/swap.ts
+++ b/src/swap.ts
@@ -24,7 +24,8 @@ import { _prettyPrint, _throwIfNotAtom } from "./utils";
  */
 export function swap<S>(atom: Atom<S>, updateFn: (state: DeepImmutable<S>) => S): void {
   _throwIfNotAtom(atom);
-  const nextState = updateFn(_getState(atom));
+  const prevState = _getState(atom);
+  const nextState = updateFn(prevState);
   const validator = _getValidator(atom);
   const didValidate = validator(nextState as DeepImmutable<S>);
   if (!didValidate) {
@@ -37,6 +38,6 @@ export function swap<S>(atom: Atom<S>, updateFn: (state: DeepImmutable<S>) => S)
     throw err;
   } else {
     _setState(atom, nextState);
-    _runChangeHandlers(atom);
+    _runChangeHandlers(atom, prevState as S, nextState);
   }
 }

--- a/src/test/changeHandler.spec.ts
+++ b/src/test/changeHandler.spec.ts
@@ -1,16 +1,17 @@
 // tslint:disable:no-console
-
-import { addChangeHandler, Atom, removeChangeHandler, set, swap } from "../../src";
+import { addChangeHandler, Atom, deref, removeChangeHandler, set, swap } from "../../src";
 
 describe("Atom change handlers", function() {
   describe("addChangeHandler", function() {
-    it("registers a function of type (state -> void) that runs on every state change", function() {
+    it("registers a function that takes named params of `previous` and `current` state that runs on every state change", function() {
       const testAtom = Atom.of(1);
-      const logSpy = spyOn(console, "log");
-      function print<S>(x: S) {
-        console.log(x);
-      }
-      addChangeHandler(testAtom, "print", print);
+      const mock = { log: (...args: any[]) => null };
+      const logSpy = spyOn(mock, "log");
+      addChangeHandler(testAtom, "print", ({ previous, current }) => {
+        expect(previous).not.toBe(current);
+        expect(current).toBe(deref(testAtom));
+        mock.log(previous, current);
+      });
       swap(testAtom, x => x + 1);
       set(testAtom, 0);
       swap(testAtom, x => x + 1);
@@ -27,11 +28,13 @@ describe("Atom change handlers", function() {
   describe("removeChangeHandler", function() {
     it("unregisters the handler function at specified key so that it no longer runs on state change", function() {
       const testAtom = Atom.of(1);
-      const logSpy = spyOn(console, "log");
-      function print<S>(x: S) {
-        console.log(x);
-      }
-      addChangeHandler(testAtom, "print", print);
+      const mock = { log: (...args: any[]) => null };
+      const logSpy = spyOn(mock, "log");
+      addChangeHandler(testAtom, "print", ({ previous, current }) => {
+        expect(previous).not.toBe(current);
+        expect(current).toBe(deref(testAtom));
+        mock.log(previous, current);
+      });
       swap(testAtom, x => x + 1);
       removeChangeHandler(testAtom, "print");
       set(testAtom, 0);


### PR DESCRIPTION
`addChangeHandler` was released with a mistaken callback signature, only receiving current state.
This commit changes the callback signature to receive `previous` `current` state as named
parameters.