### PR TITLE
feat: expose internal types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { addChangeHandler, removeChangeHandler } from "./changeHandler";
 export { Atom } from "./atom";
-export { AtomState } from "./internal-types";
+export * from "./internal-types";
 export { deref } from "./deref";
 export { getValidator } from "./getValidator";
 export { set } from "./set";


### PR DESCRIPTION
type inference may be broken for consumers because some signatures contain types that are not
directly exported; this commit exports all internal types