### PR TITLE
Copy changeHandlersByAtomId before executing handlers.

### DIFF
--- a/src/internal-state.ts
+++ b/src/internal-state.ts
@@ -56,7 +56,8 @@ export function _removeChangeHandler<S>(atom: Atom<S>, key: string) {
 
 /** @ignore */
 export function _runChangeHandlers<S>(atom: Atom<S>, previous: S, current: S) {
-  Object.keys(changeHandlersByAtomId[atom["$$id"]]).forEach(k => {
-    changeHandlersByAtomId[atom["$$id"]][k]({ previous, current });
+  const handlers = { ...changeHandlersByAtomId[atom["$$id"]] };
+  Object.keys(handlers).forEach(k => {
+    handlers[k]({ previous, current });
   });
 }


### PR DESCRIPTION
Prevents handlers from removing themselves while notifying subscribers.
By fixing the list of handlers, handlers can no longer unsubscribe mid event. This allows for multiple calls to swap without causing a handler to no longer exist. 

Down stream handlers may need to determine if they are still active as a result, especially react components. 

Please see derrickbeining/react-atom#44 & derrickbeining/react-atom/pull/46

